### PR TITLE
patch: 1.1.1 - trusted-publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write  # enable GitHub OIDC token issuance for this job
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    #Build/pack the project
+    # Build/pack the project
     - name: Setup .NET ${{ env.DOTNET_VERSION }}
       uses: actions/setup-dotnet@v4
       with:
@@ -29,11 +32,18 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
 
-    - name: Test Project
-      run: dotnet test --configuration Release
-
     - name: Build and pack project # <GeneratePackageOnBuild>true</GeneratePackageOnBuild> must be added to .csproj
       run: dotnet build ${{ env.PROJECT_PATH }} --configuration Release
 
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+
+    # Get a short-lived NuGet API key (1 hour)
+    - name: NuGet login (OIDC → temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }} # Recommended: use a secret like ${{ secrets.NUGET_USER }} for your nuget.org username (profile name), NOT your email address
+
     - name: Publish NuGet package to NuGet.org
-      run: dotnet nuget push ${{ env.PROJECT_RELEASE_PATH }}/*.nupkg --api-key ${{ secrets.NUGET_TOKEN }} --source ${{ env.NUGET_SOURCE }}
+      run: dotnet nuget push ${{ env.PROJECT_RELEASE_PATH }}/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source ${{ env.NUGET_SOURCE }}

--- a/Vestfold.Extensions.Logging/Vestfold.Extensions.Logging.csproj
+++ b/Vestfold.Extensions.Logging/Vestfold.Extensions.Logging.csproj
@@ -7,7 +7,7 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
         <PackageId>Vestfold.Extensions.Logging</PackageId>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
         <Authors>Rune Moskvil Lyngås</Authors>
         <Company>Vestfold fylkeskommune</Company>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
### Maintenance commits:
- chore: Use Trusted Publishing instead of long-lived API keys (16490df)
