### PR TITLE
feat: use flat JSON formatter for Azure Log Analytics sink

### DIFF
--- a/Vestfold.Extensions.Logging/LoggingExtension.cs
+++ b/Vestfold.Extensions.Logging/LoggingExtension.cs
@@ -1,14 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.AzureLogAnalytics;
+using Serilog.Templates;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
 using Vestfold.Extensions.Logging.Models;
 
 namespace Vestfold.Extensions.Logging;
@@ -39,10 +40,21 @@ public static class LoggingExtension
 
             if (loggingValues.AzureLogAnalytics.Enabled)
             {
+                // Flat JSON formatter required by Azure DCR transformation
+                var formatter = new ExpressionTemplate(
+                    "{ " +
+                    "\"TimeGenerated\": @t, " +
+                    "\"Level\": @l, " +
+                    "\"Message\": @m, " +
+                    "\"Exception\": @x, " +
+                    "@@p " +
+                    "}"
+                );
+
                 loggerConfiguration
                     .WriteTo.Logger(loggerConfig => loggerConfig
                         .Filter.ByIncludingOnly(logEvent => LoggerFilter(logEvent, loggingValues.AzureLogAnalytics.PropertiesToInclude, loggingValues.AzureLogAnalytics.PropertiesToExclude))
-                        .WriteTo.AzureLogAnalytics(loggingValues.AzureLogAnalytics.Credential, new ConfigurationSettings
+                        .WriteTo.AzureLogAnalytics(formatter, loggingValues.AzureLogAnalytics.Credential, new ConfigurationSettings
                         {
                             BatchSize = loggingValues.AzureLogAnalytics.BatchSize,
                             BufferSize = loggingValues.AzureLogAnalytics.BufferSize,

--- a/Vestfold.Extensions.Logging/Vestfold.Extensions.Logging.csproj
+++ b/Vestfold.Extensions.Logging/Vestfold.Extensions.Logging.csproj
@@ -7,7 +7,7 @@
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
         <PackageId>Vestfold.Extensions.Logging</PackageId>
-        <Version>3.1.0</Version>
+        <Version>3.2.0</Version>
         <Authors>Rune Moskvil Lyngås</Authors>
         <Company>Vestfold fylkeskommune</Company>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/Vestfold.Extensions.Logging/Vestfold.Extensions.Logging.csproj
+++ b/Vestfold.Extensions.Logging/Vestfold.Extensions.Logging.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
         <PackageReference Include="Serilog.Enrichers.GlobalLogContext" Version="3.0.0" />
+        <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
         <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />


### PR DESCRIPTION
Bruker flat JSON-formatter (ExpressionTemplate) for Azure Log Analytics-sinken, slik at properties flates ut på rotnivå i stedet for å nestes under Event. Dette er påkrevd for at DCR-transformasjonen skal kunne prosessere innkommende data korrekt.